### PR TITLE
Fix warning occurances

### DIFF
--- a/src/templates/partials/occurances.hbs
+++ b/src/templates/partials/occurances.hbs
@@ -26,7 +26,7 @@
   <div class="table-column">
     <h3>Warnings</h3>
 
-    {{#if errorOccurances.length}}
+    {{#if warningOccurances.length}}
       <table class="summary-table">
         <tbody>
           {{#each warningOccurances}}


### PR DESCRIPTION
If there are no errors, common warnings are not printed out.